### PR TITLE
updated api version networking for ingress in k8s

### DIFF
--- a/k8s/dashboard.yml
+++ b/k8s/dashboard.yml
@@ -83,13 +83,16 @@ metadata:
   name: dashboard
 spec:
   rules:
-    - host: ssl-checks.local
+    - host: "ssl-checks.local"
       http:
         paths:
-          - path: /
+          - pathType: Prefix
+            path: "/"
             backend:
-              serviceName: dashboard
-              servicePort: 8080
+              service:
+                name: dashboard
+                port:
+                  number: 8080
 ---
 # redis
 apiVersion: v1

--- a/k8s/dashboard.yml
+++ b/k8s/dashboard.yml
@@ -77,7 +77,7 @@ spec:
   selector:
     app: dashboard
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: dashboard


### PR DESCRIPTION
In K8s yaml files networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; There is a recommendation to use networking.k8s.io/v1 Ingress
